### PR TITLE
Fix to outbox - send message "send" to itself

### DIFF
--- a/src/outbox.erl
+++ b/src/outbox.erl
@@ -141,6 +141,7 @@ outbox_routine(Zone, Delay) ->
                     no_events -> initial_delay();
                     {error, _} -> min( trunc(Delay * backoff_factor()), maximum_delay() )
                 end,
+            timer:send_after(NextDelay, send),
             outbox_routine(Zone, NextDelay);
         {event, {Vertex, Event}} ->
             queue_event(Zone, Vertex, Event),


### PR DESCRIPTION
After trying to send event Batch process should send to itself
message "send" to try sending next batch after some delay.