### PR TITLE
Fix naive effective-permissions query

### DIFF
--- a/gmm_client/test/naive_queries_SUITE.erl
+++ b/gmm_client/test/naive_queries_SUITE.erl
@@ -102,9 +102,9 @@ operations_test(_Config) ->
     ?assertEqual(true, ReachesResponse3),
     ?assertEqual(true, ReachesResponse4),
 
-    ?assertEqual(<<"01110">>, EPResponse1),
-    ?assertEqual(<<"01101">>, EPResponse2),
-    ?assertEqual(<<"00011">>, EPResponse3).
+    ?assertEqual(<<"10101">>, EPResponse1),
+    ?assertEqual(<<"11110">>, EPResponse2),
+    ?assertEqual(<<"11110">>, EPResponse3).
 
 operations_after_graph_update_test(_Config) ->
     % when
@@ -146,6 +146,6 @@ operations_after_graph_update_test(_Config) ->
     ?assertEqual(true, ReachesResponse3),
     ?assertEqual(true, ReachesResponse4),
 
-    ?assertEqual(<<"01110">>, EPResponse1),
+    ?assertEqual(<<"10101">>, EPResponse1),
     ?assertEqual(<<"00000">>, EPResponse2),
-    ?assertEqual(<<"00011">>, EPResponse3).
+    ?assertEqual(<<"01010">>, EPResponse3).

--- a/src/rest/handlers/rest_queries.erl
+++ b/src/rest/handlers/rest_queries.erl
@@ -181,7 +181,7 @@ effective_permissions_naive_locally(From, To, JumpCount) ->
             lists:foldr(
                 fun
                     (_, {error, Reason}) -> {error, Reason};
-                    (To, {ok, Acc}) ->
+                    (ToInner, {ok, Acc}) when ToInner == To ->
                         case graph:get_edge(From, To) of
                             {error, Reason} -> {error, Reason};
                             {ok, #{<<"permissions">> := Perm}} -> {ok, JoinPermissions(Perm, Acc)}


### PR DESCRIPTION
There was a problem with variable being shadowed in lambda.
It wasn't found earlier because of incorrect naive_queries tests.