### PR TITLE
Change default routing to k8s-compliant

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,40 +1,43 @@
 version: '3'
 
 services:
-    gmm_server:
+    zone0:
         image: gmmindexererlang:latest
-        container_name: gmm_server
+        container_name: zone0
         stdin_open: true
         environment:
             - GMM_REDIS_HOST=127.0.0.1
             - ZONE_ID=zone0
             - PORT=8080
+            - LOCAL_TESTS=true
         expose:
             - "8080"
         ports:
             - 8080:8080
 
-    gmm_server2:
+    zone1:
         image: gmmindexererlang:latest
-        container_name: gmm_server2
+        container_name: zone1
         stdin_open: true
         environment:
             - GMM_REDIS_HOST=127.0.0.1
             - ZONE_ID=zone1
             - PORT=8081
+            - LOCAL_TESTS=true
         expose:
             - "8081"
         ports:
             - 8081:8081
 
-    gmm_server3:
+    zone2:
         image: gmmindexererlang:latest
-        container_name: gmm_server3
+        container_name: zone2
         stdin_open: true
         environment:
             - GMM_REDIS_HOST=127.0.0.1
             - ZONE_ID=zone2
             - PORT=8082
+            - LOCAL_TESTS=true
         expose:
             - "8082"
         ports:

--- a/gmm_client/test/naive_queries_redis_outside_SUITE_data/docker-compose.yml
+++ b/gmm_client/test/naive_queries_redis_outside_SUITE_data/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-    redis:
+    redis0:
         image: redis:latest
         container_name: redis
         ports:
@@ -10,7 +10,7 @@ services:
             - ./config/redis.conf:/redis.conf
         command: [ "redis-server", "/redis.conf", "--port", "6379" ]
 
-    gmm_server:
+    zone0:
         image: gmmindexererlang:latest
         container_name: gmm_server
         stdin_open: true
@@ -20,14 +20,15 @@ services:
             - GMM_REDIS_HOST=redis
             - GMM_REDIS_PORT=6379
             - PORT=8080
+            - LOCAL_TESTS=true
         expose:
             - "8080"
         ports:
             - 8080:8080
         depends_on:
-            - redis
+            - redis0
 
-    redis2:
+    redis1:
         image: redis:latest
         container_name: redis2
         ports:
@@ -36,7 +37,7 @@ services:
             - ./config/redis.conf:/redis.conf
         command: [ "redis-server", "/redis.conf", "--port", "6380" ]
 
-    gmm_server2:
+    zone1:
         image: gmmindexererlang:latest
         container_name: gmm_server2
         stdin_open: true
@@ -46,14 +47,15 @@ services:
             - GMM_REDIS_HOST=redis2
             - GMM_REDIS_PORT=6380
             - PORT=8081
+            - LOCAL_TESTS=true
         expose:
             - "8081"
         ports:
             - 8081:8081
         depends_on:
-            - redis2
+            - redis1
 
-    redis3:
+    redis2:
         image: redis:latest
         container_name: redis3
         ports:
@@ -62,7 +64,7 @@ services:
             - ./config/redis.conf:/redis.conf
         command: [ "redis-server", "/redis.conf", "--port", "6381" ]
 
-    gmm_server3:
+    zone2:
         image: gmmindexererlang:latest
         container_name: gmm_server3
         stdin_open: true
@@ -72,9 +74,10 @@ services:
             - GMM_REDIS_HOST=redis3
             - GMM_REDIS_PORT=6381
             - PORT=8082
+            - LOCAL_TESTS=true
         expose:
             - "8082"
         ports:
             - 8082:8082
         depends_on:
-            - redis3
+            - redis2

--- a/src/rest/executor/http_utils.erl
+++ b/src/rest/executor/http_utils.erl
@@ -20,14 +20,16 @@
 %% Router
 
 -spec get_address(Zone :: binary()) -> {ok, binary()} | {error, any()}.
-get_address(<<"zone0">>) ->
-    {ok, <<"gmm_server:8080">>};
-get_address(<<"zone1">>) ->
-    {ok, <<"gmm_server2:8081">>};
-get_address(<<"zone2">>) ->
-    {ok, <<"gmm_server3:8082">>};
 get_address(Zone) ->
-    {error, {zone_not_found, Zone}}.
+    case settings:get_local_tests() of
+        true -> {ok, <<Zone/binary, ":", (get_port(Zone))/binary>>};
+        false -> {ok, Zone}
+    end.
+
+get_port(Zone) ->
+    [<<>>, IdxBin] = binary:split(Zone, <<"zone">>),
+    Port = 8080 + binary_to_integer(IdxBin),
+    integer_to_binary(Port).
 
 %% URL builder
 

--- a/src/rest/gmm_http_server.erl
+++ b/src/rest/gmm_http_server.erl
@@ -134,5 +134,5 @@ start_server() ->
 
 -spec get_port() -> integer().
 get_port() ->
-    EnvVar = os:getenv("PORT", "8080"),
+    EnvVar = os:getenv("PORT", "80"),
     list_to_integer(EnvVar).

--- a/src/settings.erl
+++ b/src/settings.erl
@@ -16,7 +16,9 @@
     get_instrumentation_enabled/0,
 
     set_events_batch_size/1,
-    get_events_batch_size/0
+    get_events_batch_size/0,
+
+    get_local_tests/0
 ]).
 
 -define(TABLE, settings).
@@ -24,6 +26,7 @@
 -define(INDEXATION, indexation).
 -define(INSTRUMENTATION, instrumentation).
 -define(EVENTS_BATCH_SIZE, e_batch_size).
+-define(LOCAL_TESTS, local_tests).
 
 
 %%%---------------------------
@@ -31,10 +34,13 @@
 %%%---------------------------
 
 create_ets() ->
+    LocalTests = os:getenv("LOCAL_TESTS") =/= false,
+
     ets:new(?TABLE, [named_table, public, {read_concurrency, true}]),
     ets:insert(?TABLE, {?INDEXATION, false}),
     ets:insert(?TABLE, {?INSTRUMENTATION, false}),
-    ets:insert(?TABLE, {?EVENTS_BATCH_SIZE, 5}).
+    ets:insert(?TABLE, {?EVENTS_BATCH_SIZE, 5}),
+    ets:insert(?TABLE, {?LOCAL_TESTS, LocalTests}).
 
 
 set_indexation_enabled(Bool) when is_boolean(Bool) ->
@@ -55,3 +61,7 @@ set_events_batch_size(Size) when is_integer(Size), Size > 0 ->
 
 get_events_batch_size() ->
     ets:lookup_element(?TABLE, ?EVENTS_BATCH_SIZE, 2).
+
+
+get_local_tests() ->
+    ets:lookup_element(?TABLE, ?LOCAL_TESTS, 2).


### PR DESCRIPTION
Tests require addresses to be of form "name:port".
However, k8s requires addresses of form "name".

So I decided to make k8s-compliant way a default one,
and if zone is used for test purposes it needs to have
environmental variable LOCAL_TESTS set (to any value).

Also, now deafult port inside containers is 80 instead of 8080.