### PR TITLE
Remove default limit for number of connection cowboy accepts

### DIFF
--- a/src/rest/gmm_http_server.erl
+++ b/src/rest/gmm_http_server.erl
@@ -125,7 +125,7 @@ start_server() ->
         ]}
     ]),
     {ok, _} = cowboy:start_clear(my_http_listener,
-        [{port, get_port()}],
+        [{port, get_port()}, {max_connections, infinity}],
         #{
             request_timeout => ?MAX_TIMEOUT,
             env => #{dispatch => Dispatch}


### PR DESCRIPTION
Default limit of connections was causing out tests
to throw an error during graph loading.

Now cowboy will accept as many connections as possible.